### PR TITLE
Change casadi_symbolic_mode to use full class names

### DIFF
--- a/src/matlab/define_casadi_symbolic.m
+++ b/src/matlab/define_casadi_symbolic.m
@@ -3,9 +3,9 @@ import casadi.*
     if nargin < 3
         size = 1;
     end
-    if strcmp(type, 'SX')
+    if strcmp(type, 'casadi.SX')
         sym = SX.sym(name, size);
-    elseif strcmp(type, 'MX')
+    elseif strcmp(type, 'casadi.MX')
         sym = MX.sym(name, size);
     else
         error('Type must be MX or SX.')

--- a/src/matlab/model_reformulation_nosnoc.m
+++ b/src/matlab/model_reformulation_nosnoc.m
@@ -85,7 +85,7 @@ model.h = h;
 model.h_k = h_k;
 model.N_finite_elements = N_finite_elements;
 %% Determine is the SX or MX mode in CasADi used.
-casadi_symbolic_mode = model.x(1).type_name();
+casadi_symbolic_mode = class(model.x(1));
 settings.casadi_symbolic_mode  = casadi_symbolic_mode;
 settings.couple_across_stages = 1;
 
@@ -272,7 +272,7 @@ if ~exist('S')
                 % discrimnant functions
                 g_ind_vec =  [g_ind_vec;g_ind{ii};];
                 g_ind_all{ii} = g_ind{ii};
-                c_all = [c_all; 0];
+                c_all = [c_all; zeros(1,casadi_symbolic_mode)];
             end
         else
             error(['Neither the sign matrix S nor the indicator functions g_ind for regions are provided. ' ...


### PR DESCRIPTION
`c_all` can possibly be entirely made of zeros. If this happens the  call `dot_c = c_all.jacobian(x)*f_x;` on line 765 will fail as it is not a casadi type. Getting the full class name instead of the `type_name()` allows the use of `zeros`. There may be some other places this can be used but this is the only place where a crash occurred.