### PR TITLE
added optional constraint stabilization in time-freezing

### DIFF
--- a/examples/disc_manipulation/disc_around_obstacle.m
+++ b/examples/disc_manipulation/disc_around_obstacle.m
@@ -46,7 +46,7 @@ settings.use_fesd = 1;
 settings.N_homotopy = 7;
 settings.opts_ipopt.ipopt.max_iter = 1e3;
 settings.time_freezing = 1;
-
+settings.stabilizing_q_dynamics = 1;
 % enforce inequality at finite elements.
 settings.g_path_at_fe = 1;
 

--- a/src/default_settings_nosnoc.m
+++ b/src/default_settings_nosnoc.m
@@ -29,7 +29,7 @@ initial_lambda_1 = 1;
 initial_beta = 1;
 initial_theta_step = 1;
 
-pss_lift_step_functions = 1; % lift the multilinear terms in the step functions;
+pss_lift_step_functions = 0; % lift the multilinear terms in the step functions;
 n_depth_step_lifting = 2; % it is not recomended to change this (increase nonlinearity and harms convergenc), depth is number of multilinar terms to wich a lifting variables is equated to.
 
 list_of_all_rk_schemes = {'radau','legendre','Radau-IIA','Gauss-Legendre','Radau-I','Radau-IA',...
@@ -128,6 +128,9 @@ friction_exists = 0;
 % exerimentla expert otpions
 nonsmooth_switching_fun = 0; % experimental: use c = max(c1,c2) insetad of c = [c1;c2]  
 
+% expert mode: stabilize auxiliary dynamics in \nabla f_c(q) direction
+stabilizing_q_dynamics = 0;
+kappa_stabilizing_q_dynamics = 1e-5;
 %% Verbose
 print_level = 3;
 

--- a/src/time_freezing_reformulation.m
+++ b/src/time_freezing_reformulation.m
@@ -245,12 +245,12 @@ if ~time_freezing_model_exists
         f_aux_pos = []; % matrix wit all aux tan dyn
         f_aux_neg = [];
         % time freezing dynamics
-        f_q_dynamics = zeros(n_q,1);
         if settings.stabilizing_q_dynamics
-            f_aux_normal = [-settings.kappa_stabilizing_q_dynamics*J_normal.*(f_c);inv_M_aux*J_normal*a_n;zeros(1,n_contacts)];
+            f_q_dynamics = -settings.kappa_stabilizing_q_dynamics*J_normal.*(f_c);
         else
-            f_aux_normal = [f_q_dynamics;J_normal*a_n;zeros(1,n_contacts)];
+            f_q_dynamics = zeros(n_q,1);
         end
+        f_aux_normal = [f_q_dynamics;inv_M_aux*J_normal*a_n;zeros(1,n_contacts)];
 
         for ii = 1:n_contacts
             if settings.stabilizing_q_dynamics


### PR DESCRIPTION
A small feature for experts that can improve the convergence.
The q dynamics of the auxiliary dynamics is per default zero and has a zero sensitivity.
However, adding a small linear dynamics term does not change the solution but adds a nonzero sensitivity and improves convergence. 
Additionally, I turned off pss_lift in default settings to zero, since it is not fully implemented for step. 