### PR TITLE
Fix nu function and step equilibration options. Implement CLS nu function

### DIFF
--- a/src/FiniteElement.m
+++ b/src/FiniteElement.m
@@ -1050,13 +1050,23 @@ classdef FiniteElement < NosnocFormulationObject
                         sigma_discont_F = sum2(horzcat(theta_F{:}));
                         sigma_discont_B = sum2(horzcat(theta_B{:}));
                     case DcsMode.Step
-                        % TODO step
+                        lam_p_F = cellfun(@(x) obj.w(x), obj.ind_lambda_p, 'uni', false);
+                        lam_p_B = cellfun(@(x) obj.prev_fe.w(x), obj.prev_fe.ind_lambda_p, 'uni', false);
+                        lam_n_F = cellfun(@(x) obj.w(x), obj.ind_lambda_n, 'uni', false);
+                        lam_n_B = cellfun(@(x) obj.prev_fe.w(x), obj.prev_fe.ind_lambda_n, 'uni', false);
+                        alpha_F = cellfun(@(x) obj.w(x), obj.ind_alpha, 'uni', false);
+                        alpha_B = cellfun(@(x) obj.prev_fe.w(x), obj.prev_fe.ind_alpha, 'uni', false);
+
+                        sigma_cont_F = vertcat(sum2(horzcat(lam_n_F{:})), sum2(horzcat(lam_p_F{:})));
+                        sigma_cont_B = vertcat(sum2(horzcat(lam_n_B{:})), sum2(horzcat(lam_p_B{:})));
+                        sigma_discont_F = vertcat(sum2(horzcat(alpha_F{:})), sum2(1-horzcat(alpha_F{:})));
+                        sigma_discont_B = vertcat(sum2(horzcat(alpha_B{:})), sum2(1-horzcat(alpha_B{:})));
                     case DcsMode.CLS
                 end
                 pi_cont = sigma_cont_B .* sigma_cont_F;
                 pi_discont = sigma_discont_B .* sigma_discont_F;
                 nu = pi_cont + pi_discont;
-                
+                 
                 nu_vector = 1;
                 for jjj=1:length(nu)
                     nu_vector = nu_vector * nu(jjj);

--- a/src/FiniteElement.m
+++ b/src/FiniteElement.m
@@ -1121,19 +1121,19 @@ classdef FiniteElement < NosnocFormulationObject
                                     else
                                         % TODO: Verify
                                         gamma_F = cellfun(@(x) obj.w(x), obj.ind_gamma_d, 'uni', false);
-                                        gamma_B = cellfun(@(x) obj.prev_fe.w(x), obj.prev_fe.ind_p_vt, 'uni', false);
+                                        gamma_B = cellfun(@(x) obj.prev_fe.w(x), obj.prev_fe.ind_gamma_d, 'uni', false);
                                         beta_F = cellfun(@(x) obj.w(x), obj.ind_beta_d, 'uni', false);
                                         beta_B = cellfun(@(x) obj.prev_fe.w(x), obj.prev_fe.ind_beta_d, 'uni', false);
 
                                         sigma_gamma_F = sum2(horzcat(gamma_F{:}));
-                                        sigma_gamma_B = sum2(horzcat(gamma_B{:}));;
-                                        sigma_beta_F = sum2(horzcat(beta_F{:}));;
-                                        sigma_beta_B = sum2(horzcat(bet_B{:}));;
+                                        sigma_gamma_B = sum2(horzcat(gamma_B{:}));
+                                        sigma_beta_F = sum2(horzcat(beta_F{:}));
+                                        sigma_beta_B = sum2(horzcat(beta_B{:}));
                                         
                                         pi_gamma = sigma_gamma_F.*sigma_gamma_B;
                                         pi_beta = sigma_beta_F.*sigma_beta_B;
 
-                                        zeta(ii) = (sigma_f_c_B + sigma_f_c_F) + (sum(pi_gamma) + pi_beta);
+                                        zeta(ii) = 1;%(sigma_f_c_B + sigma_f_c_F) + (sum(pi_gamma) + sum(pi_beta));
                                     end
                                 end
                             end


### PR DESCRIPTION
Step equilibration (that relies on $\nu$) was broken during implementation of CLS/splitting of NLP and MPCC generation. This attempts to bring that back into working order.