### PR TITLE
Implement required modifications for vdx speedup

### DIFF
--- a/+nosnoc/+discrete_time_problem/Cls.m
+++ b/+nosnoc/+discrete_time_problem/Cls.m
@@ -1387,6 +1387,8 @@ classdef Cls < vdx.problems.Mpcc
                 plugin = 'scholtes_ineq';
             end
 
+            obj.finalize_assignments();
+            
             % Sort by indices to recover almost block-band structure.
             obj.w.sort_by_index();
             obj.g.sort_by_index();

--- a/+nosnoc/+discrete_time_problem/Gcs.m
+++ b/+nosnoc/+discrete_time_problem/Gcs.m
@@ -804,6 +804,8 @@ classdef Gcs < vdx.problems.Mpcc
                 regenerate = false;
             end
 
+            obj.finalize_assignments();
+            
             % Sort by indices to recover almost block-band structure.
             % TODO: Maybe it would be useful to do a custom sorting for FESD to make the problem maximally block band.
             %       This is almost certainly necessary if we want to take advantage of e.g. FATROP. 

--- a/+nosnoc/+discrete_time_problem/Heaviside.m
+++ b/+nosnoc/+discrete_time_problem/Heaviside.m
@@ -908,6 +908,8 @@ classdef Heaviside < vdx.problems.Mpcc
                 plugin = 'scholtes_ineq';
             end
 
+            obj.finalize_assignments();
+            
             % Sort by indices to recover almost block-band structure.
             obj.w.sort_by_index();
             obj.g.sort_by_index();

--- a/+nosnoc/+discrete_time_problem/Stewart.m
+++ b/+nosnoc/+discrete_time_problem/Stewart.m
@@ -886,6 +886,8 @@ classdef Stewart < vdx.problems.Mpcc
                 plugin = 'scholtes_ineq';
             end
 
+            obj.finalize_assignments();
+
             % Sort by indices to recover almost block-band structure.
             obj.w.sort_by_index();
             obj.g.sort_by_index();


### PR DESCRIPTION
This implements an algorithm that collects delays actual concatenation of casadi symbolics until as late as possible as vertcat with many arguments is _much_ (order of magnitude) more efficient than chained vertcats.

This also gives us back nice variable name whereas the last speedup approach required us to give up the indices in the symbolic names.